### PR TITLE
关于「设置」的小小修改

### DIFF
--- a/src/javascript/SettingManager.js
+++ b/src/javascript/SettingManager.js
@@ -4,66 +4,42 @@ class SettingManager {
     // 默认值常量
     static DEFAULT_PRIMARY_COLOR = "#ad6eca";
     static DEFAULT_SECONDARY_COLOR = "#3b91d8";
-    static DEFAULT_MICA_OPACITY = 0.5;
     static DEFAULT_FONT_FAMILY_CUSTOM = "HarmonyOS_Sans";
     static DEFAULT_FONT_FAMILY_FALLBACK = "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell";
-    static DEFAULT_VOLUME = 50; // 新增：默认音量50dB
+
     static DEFAULT_VALUES = {
-        // 默认音量为50%
-        volume: "50",
-        
-        // 默认启用歌词
-        lyricsEnabled: "true",
-        
-        // 默认启用循环歌词同步
-        loopLyricsEnabled: "true",
-        
-        // 默认禁用开发者工具
-        devToolsEnabled: "false",
-        
-        // 默认背景为封面
-        background: "cover",
-        
-        // 默认启用缓存
-        cacheEnabled: "true",
-        
-        // 默认关闭淡入淡出效果
-        fadeEnabled: "false",
-        
-        // 默认自动解析视频标题
-        extractTitle: "true",
-        
-        // 默认不启用桌面歌词
-        desktopLyricsEnabled: "false",
-        
-        // 默认禁用启动时自动播放
-        autoPlayOnStartup: "false"
+        theme: "dark",
+        hideSidebar: false,
+        hideTitbar: false,
+        primaryColor: SettingManager.DEFAULT_PRIMARY_COLOR, // 默认主色
+        secondaryColor: SettingManager.DEFAULT_SECONDARY_COLOR, // 默认次色
+        micaOpacity: 0.5, // 默认Mica透明度
+        background: "video",
+        autoMaximize: false,
+
+        fontFamilyCustom: SettingManager.DEFAULT_FONT_FAMILY_CUSTOM,
+        lyricLineFontSize: 24,
+
+        lyricsEnabled: true,
+        lyricSource: "netease", // 歌词来源 默认使用网易云
+        autoPlayOnStartup: false, // 自动播放
+        loopLyricsEnabled: true, // 循环歌单歌词同步功能 默认开启
+        desktopLyricsEnabled: false,
+        fadeEnabled: true, // 音频淡入淡出效果
+
+        lyricSearchType: "custom",
+        extractTitle: "auto",
+        videoQuality: 64, // 背景视频清晰度 默认720P
+        cacheEnabled: false,
+
+        fontFamilyFallback: SettingManager.DEFAULT_FONT_FAMILY_FALLBACK,
+        devToolsEnabled: false, // 开发者工具设置
+
+        volume: 50, // 音量设置
     };
 
     constructor() {
-        this.settings = {
-            theme: "dark",
-            background: "video",
-            lyricSearchType: "custom",
-            lyricsEnabled: true,
-            extractTitle: "auto",
-            cacheEnabled: false,
-            fadeEnabled: true, // 新增：控制淡入淡出效果
-            primaryColor: SettingManager.DEFAULT_PRIMARY_COLOR, // 默认主色
-            secondaryColor: SettingManager.DEFAULT_SECONDARY_COLOR, // 默认次色
-            micaOpacity: SettingManager.DEFAULT_MICA_OPACITY, // 默认Mica透明度
-            fontFamilyCustom: SettingManager.DEFAULT_FONT_FAMILY_CUSTOM,
-            fontFamilyFallback: SettingManager.DEFAULT_FONT_FAMILY_FALLBACK,
-            videoQuality: 64, // 新增：背景视频清晰度，默认720P
-            hideSidebar: false,
-            hideTitbar: false,
-            devToolsEnabled: false, // 新增：开发者工具设置，默认禁用
-            autoMaximize: false,
-            lyricSource: "netease", // 新增：歌词来源，默认使用网易云
-            volume: SettingManager.DEFAULT_VOLUME, // 已存在的音量设置
-            loopLyricsEnabled: true, // 新增：循环歌单歌词同步功能，默认开启
-            autoPlayOnStartup: false
-        };
+        this.settings = { __proto__: SettingManager.DEFAULT_VALUES };
         this.listeners = new Map();
         this.STORAGE_KEY = "app_settings";
         this.loadSettings();
@@ -79,10 +55,9 @@ class SettingManager {
         try {
             const savedSettings = localStorage.getItem(this.STORAGE_KEY);
             if (savedSettings) {
-                const ss = JSON.parse(savedSettings);
-                for (const key in ss)
-                    if (Object.prototype.hasOwnProperty.call(ss, key))
-                        this.settings[key] = ss[key];
+                const parsed = JSON.parse(savedSettings);
+                for (const k in parsed)
+                    this.settings[k] = parsed[k];
             }
         } catch (error) {
             console.error("加载设置失败:", error);
@@ -245,6 +220,14 @@ class SettingManager {
             (value) => `${Math.round(value * 100)}%`,
             () => this.applyMicaOpacity()
         );
+
+        this.sliderSetting(
+            "lyricLineFontSize",
+            "24px",
+            "歌词字体大小已重置",
+            (value) => `${value}px`,
+            () => this.applyFontSize()
+        );
     }
 
     sliderSetting(id, defaultValue, resetText, value2display, afterValueApply) {
@@ -298,6 +281,11 @@ class SettingManager {
         if (typeof c === "string" && c.trim().length > 0) c = `${c}, `;
         root.style.setProperty("--font-family-custom", c);
         root.style.setProperty("--font-family-fallback", this.settings.fontFamilyFallback);
+    }
+
+    applyFontSize() {
+        const root = document.documentElement;
+        root.style.setProperty("--lyric-line-font-size", `${this.settings.lyricLineFontSize}px`);
     }
 
     applySettingChange(key, value) {

--- a/src/main.html
+++ b/src/main.html
@@ -498,12 +498,14 @@
               </div>
             </div>
           </div>
-          <!-- 外观设置 -->
+
+          <!-- region 外观设置 -->
           <div class="setting-category">
             <div class="setting-category-title"><i class="bi bi-palette"></i> 外观设置</div>
             <div class="setting-category-description">调整NB Music的视觉效果</div>
           </div>
           <div class="setting-group">
+
             <div class="setting-item">
               <div class="setting-info">
                 <i class="bi bi-circle-half"></i>
@@ -520,6 +522,7 @@
                 </nav>
               </div>
             </div>
+
             <div class="setting-item">
               <div class="setting-info">
                 <i class="bi bi-layout-sidebar"></i>
@@ -535,6 +538,7 @@
                 </nav>
               </div>
             </div>
+
             <div class="setting-item">
               <div class="setting-info">
                 <i class="bi bi-window-fullscreen"></i>
@@ -550,6 +554,7 @@
                 </nav>
               </div>
             </div>
+
             <!-- 主题色选择器 -->
             <div class="setting-item">
               <div class="setting-info">
@@ -589,6 +594,7 @@
                 </button>
               </div>
             </div>
+
             <!-- 背景填充 -->
             <div class="setting-item">
               <div class="setting-info">
@@ -609,6 +615,33 @@
 
             <div class="setting-item">
               <div class="setting-info">
+                <i class="bi bi-arrows-fullscreen"></i>
+                <div class="words">
+                  <div class="setting-name">自动全屏</div>
+                  <div class="setting-descrition">是否打开软件就自动全屏</div>
+                </div>
+              </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav-auto-maximize">
+                  <a data-key="autoMaximize" data-value="true">启用</a>
+                  <a data-key="autoMaximize" data-value="false" class="active">禁用</a>
+                </nav>
+              </div>
+
+            </div>
+
+          </div>
+          <!-- endregion 外观设置 -->
+
+          <!-- region 字体设置 -->
+          <div class="setting-category">
+            <div class="setting-category-title"><i class="bi bi-fonts"></i> 字体设置</div>
+            <div class="setting-category-description">调整字体相关设置</div>
+          </div>
+          <div class="setting-group">
+
+            <div class="setting-item">
+              <div class="setting-info">
                 <i class="bi bi-fonts"></i>
                 <div class="words">
                   <div class="setting-name">自定义字体</div>
@@ -624,291 +657,309 @@
 
             <div class="setting-item">
               <div class="setting-info">
-                <i class="bi bi-arrows-fullscreen"></i>
+                <i class="bi bi-fonts"></i>
                 <div class="words">
-                  <div class="setting-name">自动全屏</div>
-                  <div class="setting-descrition">是否打开软件就自动全屏</div>
+                  <div class="setting-name">歌词字体大小</div>
+                  <div class="setting-descrition">调整播放界面的歌词字体大小（不能调整桌面歌词）</div>
+                </div>
+              </div>
+              <div class="setting-value slider-container">
+                <input type="range" id="lyricLineFontSize" min="10" max="50" step="1" class="slider" />
+                <span id="lyricLineFontSizeValue">24px</span>
+                <button id="lyricLineFontSizeReset" class="reset-btn" title="重置为默认值">
+                  <i class="bi bi-arrow-counterclockwise"></i>
+                </button>
+              </div>
+            </div>
+
+          </div>
+          <!-- endregion 字体设置 -->
+
+          <!-- region 播放设置 -->
+          <div class="setting-category">
+            <div class="setting-category-title"><i class="bi bi-music-note-beamed"></i> 播放设置</div>
+            <div class="setting-category-description">调整音频播放相关功能</div>
+          </div>
+          <div class="setting-group">
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-chat-square-text"></i>
+                <div class="words">
+                  <div class="setting-name">歌词显示</div>
+                  <div class="setting-descrition">是否显示歌词</div>
                 </div>
               </div>
               <div class="setting-value">
-                <nav data-nav-id="nav-auto-maximize">
-                  <a data-key="autoMaximize" data-value="true">启用</a>
-                  <a data-key="autoMaximize" data-value="false" class="active">禁用</a>
+                <nav data-nav-id="nav-lyrics">
+                  <a class="active" data-key="lyricsEnabled" data-value="true">显示歌词</a>
+                  <a data-key="lyricsEnabled" data-value="false">隐藏歌词</a>
                 </nav>
               </div>
             </div>
 
-            <!-- 音频播放设置 -->
-            <div class="setting-category">
-              <div class="setting-category-title"><i class="bi bi-music-note-beamed"></i> 播放设置</div>
-              <div class="setting-category-description">调整音频播放相关功能</div>
-            </div>
-            <div class="setting-group">
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-chat-square-text"></i>
-                  <div class="words">
-                    <div class="setting-name">歌词显示</div>
-                    <div class="setting-descrition">是否显示歌词</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav-lyrics">
-                    <a class="active" data-key="lyricsEnabled" data-value="true">显示歌词</a>
-                    <a data-key="lyricsEnabled" data-value="false">隐藏歌词</a>
-                  </nav>
+            <!-- 在歌词显示设置下方添加歌词来源切换选项 -->
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-music-note-list"></i>
+                <div class="words">
+                  <div class="setting-name">歌词来源</div>
+                  <div class="setting-descrition">选择歌词来源类型</div>
                 </div>
               </div>
-
-              <!-- 在歌词显示设置下方添加歌词来源切换选项 -->
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-music-note-list"></i>
-                  <div class="words">
-                    <div class="setting-name">歌词来源</div>
-                    <div class="setting-descrition">选择歌词来源类型</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav-lyric-source">
-                    <a class="active" data-key="lyricSource" data-value="netease">网易云歌词</a>
-                    <a data-key="lyricSource" data-value="bilibili">B站字幕</a>
-                  </nav>
-                </div>
-              </div>
-
-              <!-- 添加自动播放设置 -->
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-play-circle"></i>
-                  <div class="words">
-                    <div class="setting-name">启动自动播放</div>
-                    <div class="setting-descrition">启动软件时自动开始播放上次的歌曲</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav-autoplay">
-                    <a data-key="autoPlayOnStartup" data-value="true">启用</a>
-                    <a class="active" data-key="autoPlayOnStartup" data-value="false">禁用</a>
-                  </nav>
-                </div>
-              </div>
-
-              <!-- 新增循环歌词同步设置 -->
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-arrow-repeat"></i>
-                  <div class="words">
-                    <div class="setting-name">循环歌词同步</div>
-                    <div class="setting-descrition">自动同步B站循环视频的歌词（使歌词重复播放）</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav-loop-lyrics">
-                    <a class="active" data-key="loopLyricsEnabled" data-value="true">启用</a>
-                    <a data-key="loopLyricsEnabled" data-value="false">禁用</a>
-                  </nav>
-                </div>
-              </div>
-
-              <!-- 新增桌面歌词设置 -->
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-display"></i>
-                  <div class="words">
-                    <div class="setting-name">桌面歌词</div>
-                    <div class="setting-descrition">在桌面显示独立歌词窗口</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav-desktop-lyrics">
-                    <a data-key="desktopLyricsEnabled" data-value="true">开启</a>
-                    <a class="active" data-key="desktopLyricsEnabled" data-value="false">关闭</a>
-                  </nav>
-                </div>
-              </div>
-
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-music-note"></i>
-                  <div class="words">
-                    <div class="setting-name">音频淡入淡出</div>
-                    <div class="setting-descrition">关闭可以修复部分情况下无声音的bug</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav-fade">
-                    <a class="active" data-key="fadeEnabled" data-value="true">启用</a>
-                    <a data-key="fadeEnabled" data-value="false">禁用</a>
-                  </nav>
-                </div>
-              </div>
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-film"></i>
-                  <div class="words">
-                    <div class="setting-name">背景视频质量</div>
-                    <div class="setting-descrition">设置背景视频的清晰度(背景高斯模糊，没区别，建议低一点清晰度)</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav-video-quality">
-                    <a data-key="videoQuality" data-value="16">360P</a>
-                    <a data-key="videoQuality" data-value="32">480P</a>
-                    <a class="active" data-key="videoQuality" data-value="64">720P</a>
-                    <a data-key="videoQuality" data-value="80">1080P</a>
-                    <a data-key="videoQuality" data-value="116">1080P60</a>
-                    <a data-key="videoQuality" data-value="120">4K</a>
-                  </nav>
-                </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav-lyric-source">
+                  <a class="active" data-key="lyricSource" data-value="netease">网易云歌词</a>
+                  <a data-key="lyricSource" data-value="bilibili">B站字幕</a>
+                </nav>
               </div>
             </div>
 
-            <!-- 内容与数据设置 -->
-            <div class="setting-category">
-              <div class="setting-category-title"><i class="bi bi-database"></i> 内容与数据</div>
-              <div class="setting-category-description">管理数据显示和存储方式</div>
-            </div>
-            <div class="setting-group">
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-music-note-list"></i>
-                  <div class="words">
-                    <div class="setting-name">歌词搜索</div>
-                    <div class="setting-descrition">设置歌词搜索时，关键词的设置方式</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav3">
-                    <a class="active" data-key="lyricSearchType" data-value="auto">自动搜索</a>
-                    <a data-key="lyricSearchType" data-value="custom">手动输入</a>
-                  </nav>
+            <!-- 添加自动播放设置 -->
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-play-circle"></i>
+                <div class="words">
+                  <div class="setting-name">启动自动播放</div>
+                  <div class="setting-descrition">启动软件时自动开始播放上次的歌曲</div>
                 </div>
               </div>
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-filter"></i>
-                  <div class="words">
-                    <div class="setting-name">标题处理</div>
-                    <div class="setting-descrition">如何显示歌曲标题(仅作用在侧边栏)</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav3">
-                    <a data-key="extractTitle" data-value="on">提取关键词</a>
-                    <a class="active" data-key="extractTitle" data-value="off">完整显示</a>
-                    <a data-key="extractTitle" data-value="auto">直接截断</a>
-                  </nav>
-                </div>
-              </div>
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-cloud-download"></i>
-                  <div class="words">
-                    <div class="setting-name">缓存设置</div>
-                    <div class="setting-descrition">是否开启缓存歌曲与视频(鸡肋)</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav4">
-                    <a class="active" data-key="cacheEnabled" data-value="true">开启缓存</a>
-                    <a data-key="cacheEnabled" data-value="false">关闭缓存</a>
-                  </nav>
-                  <button id="clearCache" class="cache-clear-btn">清除缓存</button>
-                </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav-autoplay">
+                  <a data-key="autoPlayOnStartup" data-value="true">启用</a>
+                  <a class="active" data-key="autoPlayOnStartup" data-value="false">禁用</a>
+                </nav>
               </div>
             </div>
 
-            <div class="setting-category">
-              <div class="setting-category-title"><i class="bi bi-gear-wide-connected"></i> 高级设置</div>
-              <div class="setting-category-description">更多高级设置 请不要随意更改 除非你知道你在做什么</div>
-            </div>
-            <div class="setting-group">
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-fonts"></i>
-                  <div class="words">
-                    <div class="setting-name">全局备用字体</div>
-                    <div class="setting-descrition">当所有自定义字体均无效时 将使用这里的字体 格式和自定义字体一样</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav-titbar-fade">
-                    <input class="input" type="text" data-key="fontFamilyFallback" />
-                  </nav>
+            <!-- 新增循环歌词同步设置 -->
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-arrow-repeat"></i>
+                <div class="words">
+                  <div class="setting-name">循环歌词同步</div>
+                  <div class="setting-descrition">自动同步B站循环视频的歌词（使歌词重复播放）</div>
                 </div>
               </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav-loop-lyrics">
+                  <a class="active" data-key="loopLyricsEnabled" data-value="true">启用</a>
+                  <a data-key="loopLyricsEnabled" data-value="false">禁用</a>
+                </nav>
+              </div>
+            </div>
+
+            <!-- 新增桌面歌词设置 -->
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-display"></i>
+                <div class="words">
+                  <div class="setting-name">桌面歌词</div>
+                  <div class="setting-descrition">在桌面显示独立歌词窗口</div>
+                </div>
+              </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav-desktop-lyrics">
+                  <a data-key="desktopLyricsEnabled" data-value="true">开启</a>
+                  <a class="active" data-key="desktopLyricsEnabled" data-value="false">关闭</a>
+                </nav>
+              </div>
+            </div>
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-music-note"></i>
+                <div class="words">
+                  <div class="setting-name">音频淡入淡出</div>
+                  <div class="setting-descrition">关闭可以修复部分情况下无声音的bug</div>
+                </div>
+              </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav-fade">
+                  <a class="active" data-key="fadeEnabled" data-value="true">启用</a>
+                  <a data-key="fadeEnabled" data-value="false">禁用</a>
+                </nav>
+              </div>
+            </div>
+
+          </div>
+          <!-- endregion 播放设置 -->
+
+          <!-- region 内容与数据设置 -->
+          <div class="setting-category">
+            <div class="setting-category-title"><i class="bi bi-database"></i> 内容与数据</div>
+            <div class="setting-category-description">管理数据显示和存储方式</div>
+          </div>
+          <div class="setting-group">
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-music-note-list"></i>
+                <div class="words">
+                  <div class="setting-name">歌词搜索</div>
+                  <div class="setting-descrition">设置歌词搜索时，关键词的设置方式</div>
+                </div>
+              </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav3">
+                  <a class="active" data-key="lyricSearchType" data-value="auto">自动搜索</a>
+                  <a data-key="lyricSearchType" data-value="custom">手动输入</a>
+                </nav>
+              </div>
+            </div>
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-filter"></i>
+                <div class="words">
+                  <div class="setting-name">标题处理</div>
+                  <div class="setting-descrition">如何显示歌曲标题(仅作用在侧边栏)</div>
+                </div>
+              </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav3">
+                  <a data-key="extractTitle" data-value="on">提取关键词</a>
+                  <a class="active" data-key="extractTitle" data-value="off">完整显示</a>
+                  <a data-key="extractTitle" data-value="auto">直接截断</a>
+                </nav>
+              </div>
+            </div>
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-film"></i>
+                <div class="words">
+                  <div class="setting-name">背景视频质量</div>
+                  <div class="setting-descrition">设置背景视频的清晰度(背景高斯模糊，没区别，建议低一点清晰度)</div>
+                </div>
+              </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav-video-quality">
+                  <a data-key="videoQuality" data-value="16">360P</a>
+                  <a data-key="videoQuality" data-value="32">480P</a>
+                  <a class="active" data-key="videoQuality" data-value="64">720P</a>
+                  <a data-key="videoQuality" data-value="80">1080P</a>
+                  <a data-key="videoQuality" data-value="116">1080P60</a>
+                  <a data-key="videoQuality" data-value="120">4K</a>
+                </nav>
+              </div>
+            </div>
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-cloud-download"></i>
+                <div class="words">
+                  <div class="setting-name">缓存设置</div>
+                  <div class="setting-descrition">是否开启缓存歌曲与视频(鸡肋)</div>
+                </div>
+              </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav4">
+                  <a class="active" data-key="cacheEnabled" data-value="true">开启缓存</a>
+                  <a data-key="cacheEnabled" data-value="false">关闭缓存</a>
+                </nav>
+                <button id="clearCache" class="cache-clear-btn">清除缓存</button>
+              </div>
+            </div>
+
+          </div>
+          <!-- endregion 内容与数据设置 -->
+
+          <!-- region 高级设置 -->
+          <div class="setting-category">
+            <div class="setting-category-title"><i class="bi bi-gear-wide-connected"></i> 高级设置</div>
+            <div class="setting-category-description">更多高级设置 请不要随意更改 除非你知道你在做什么</div>
+          </div>
+          <div class="setting-group">
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-fonts"></i>
+                <div class="words">
+                  <div class="setting-name">全局备用字体</div>
+                  <div class="setting-descrition">当所有自定义字体均无效时 将使用这里的字体 格式和自定义字体一样</div>
+                </div>
+              </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav-titbar-fade">
+                  <input class="input" type="text" data-key="fontFamilyFallback" />
+                </nav>
+              </div>
+            </div>
               
-              <!-- 添加开发者工具设置 -->
-              <div class="setting-item">
-                <div class="setting-info">
-                  <i class="bi bi-code-square"></i>
-                  <div class="words">
-                    <div class="setting-name">开发者工具</div>
-                    <div class="setting-descrition">启用后可通过F12键打开开发者工具</div>
-                  </div>
-                </div>
-                <div class="setting-value">
-                  <nav data-nav-id="nav-devtools">
-                    <a data-key="devToolsEnabled" data-value="true">启用</a>
-                    <a class="active" data-key="devToolsEnabled" data-value="false">禁用</a>
-                  </nav>
+            <!-- 添加开发者工具设置 -->
+            <div class="setting-item">
+              <div class="setting-info">
+                <i class="bi bi-code-square"></i>
+                <div class="words">
+                  <div class="setting-name">开发者工具</div>
+                  <div class="setting-descrition">启用后可通过F12键打开开发者工具</div>
                 </div>
               </div>
+              <div class="setting-value">
+                <nav data-nav-id="nav-devtools">
+                  <a data-key="devToolsEnabled" data-value="true">启用</a>
+                  <a class="active" data-key="devToolsEnabled" data-value="false">禁用</a>
+                </nav>
+              </div>
             </div>
+
           </div>
+          <!-- endregion 高级设置 -->
+
         </div>
       </div>
     </div>
-    <!-- 添加移动端播放列表浮窗 -->
-    <div class="mobile-playlist-backdrop"></div>
-    <div class="mobile-playlist">
-      <div class="playlist-drag-handle"></div>
-      <div class="mobile-playlist-header">
-        <h3 id="mobile-listname">默认歌单</h3>
-        <div class="controls">
-          <div class="playmode">
-            <i class="bi bi-repeat"></i>
-          </div>
-          <div class="rename">
-            <i class="bi bi-pencil-square"></i>
-          </div>
+  </div>
+
+  <!-- 添加移动端播放列表浮窗 -->
+  <div class="mobile-playlist-backdrop"></div>
+  <div class="mobile-playlist">
+    <div class="playlist-drag-handle"></div>
+    <div class="mobile-playlist-header">
+      <h3 id="mobile-listname">默认歌单</h3>
+      <div class="controls">
+        <div class="playmode">
+          <i class="bi bi-repeat"></i>
+        </div>
+        <div class="rename">
+          <i class="bi bi-pencil-square"></i>
         </div>
       </div>
-      <div class="mobile-playlist-content">
-        <!-- 播放列表内容会通过JS动态填充 -->
-      </div>
     </div>
+    <div class="mobile-playlist-content">
+      <!-- 播放列表内容会通过JS动态填充 -->
+    </div>
+  </div>
 
-    <!-- 添加移动端底部导航栏 -->
-    <div class="mobile-navbar">
-      <a class="active" data-page=".player">
-        <i class="bi bi-music-player"></i>
-        <span>播放</span>
-      </a>
-      <a data-page=".love-list">
-        <i class="bi bi-heart"></i>
-        <span>收藏</span>
-      </a>
-      <a class="playlist-toggle"></a>
-        <i class="bi bi-list-ul"></i>
-        <span>播放列表</span>
-        <div class="count">0</div>
-      </a>
-      <a data-page=".music-list">
-        <i class="bi bi-music-note-list"></i>
-        <span>歌单</span>
-      </a>
-      <a data-page=".setting">
-        <i class="bi bi-gear"></i>
-        <span>设置</span>
-      </a>
-    </div>
+  <!-- 添加移动端底部导航栏 -->
+  <div class="mobile-navbar">
+    <a class="active" data-page=".player">
+      <i class="bi bi-music-player"></i>
+      <span>播放</span>
+    </a>
+    <a data-page=".love-list">
+      <i class="bi bi-heart"></i>
+      <span>收藏</span>
+    </a>
+    <a class="playlist-toggle">
+      <i class="bi bi-list-ul"></i>
+      <span>播放列表</span>
+      <div class="count">0</div>
+    </a>
+    <a data-page=".music-list">
+      <i class="bi bi-music-note-list"></i>
+      <span>歌单</span>
+    </a>
+    <a data-page=".setting">
+      <i class="bi bi-gear"></i>
+      <span>设置</span>
+    </a>
+  </div>
 
-    <div class="account-options-container">
-      <div class="option" id="account-home">B站主页</div>
-      <div class="option" id="account-logout">退出登录</div>
-    </div>
+  <div class="account-options-container">
+    <div class="option" id="account-home">B站主页</div>
+    <div class="option" id="account-logout">退出登录</div>
   </div>
 
 </body>

--- a/src/styles/components/lyrics.css
+++ b/src/styles/components/lyrics.css
@@ -46,7 +46,7 @@
 
 /* 歌词行样式 */
 .lyric-line {
-  font-size: 18px;
+  font-size: var(--lyric-line-font-size);
   line-height: 1.8;
   margin: 8px 0;
   min-height: 32px;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -14,10 +14,6 @@
   --primary-color: #ad6eca;
   --secondary-color: #3b91d8;
   --mica-opacity: 0.5;
-
-  /* 其他外观 */
-  --font-family-custom: ;
-  --font-family-fallback: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell;
   
   /* 添加交互层次变量 */
   --hover-opacity: 0.85;
@@ -37,6 +33,11 @@
   --transition-fast: 150ms;
   --transition-medium: 250ms;
   --transition-slow: 350ms;
+
+  /* 字体相关 */
+  --font-family-custom: 'HarmonyOS_Sans';
+  --font-family-fallback: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell;
+  --lyric-line-font-size: 24px;
 }
 
 /* 深色主题变量 */


### PR DESCRIPTION
我也不知道会引发什么问题！在我电脑上是没问题的！需要你们帮我仔细看我改的地方对不对、仔细测试一下

- 重写了部分 `SettingManager.js`
- 修复 `main.html` 的缩进和一处`</a>``
- 为 `main.html` 的某些地方增加了空行和 `<!-- region XX -->` 注释 可以方便以后增加或改动设置项的人 保护贡献者们的眼睛（region和endregion注释可以被jetbrains家ide识别 我听说vscode加插件也能识别）
- 新增「字体设置」分类 移入「自定义字体」
- 将「背景视频质量」移动到「内容与数据」
- 增加「歌词字体大小」由 `--lyric-line-font-size`CSS变量 和 `lyricLineFontSize`设置变量 控制 归属「字体设置」分类

重写 `SettingManager.js` 的详细说明
- 修改了 `loadSettings`
- 将原本写在构造函数的默认值全部移到了 `DEFAULT_VALUES`
- 将部分不必要的 `DEFAULT_` 前缀的常量删除 并按UI排序
- 总体来说 我的预想是 现在应该只会保存用户更改过的设置项 我通过设置`__proto__`来使得当用户没有设置时会获取默认值

我觉得可能的问题
- 重构引发的一系列问题
- 没有一个好的地方来放「背景视频质量」设置项
- 字体设置的图标太单调 就那一个