### PR TITLE
自动播放

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -56,7 +56,6 @@ class App {
             this.favoriteManager = new FavoriteManager(this.playlistManager, this.uiManager);
             this.musicSearcher = new MusicSearcher();
             this.cacheManager = new CacheManager();
-            this.musiclistManager = new MusiclistManager(this.playlistManager, this.musicSearcher, this.cacheManager);
             this.loginManager = new LoginManager(this.uiManager);
             this.musiclistManager = new MusiclistManager(this.playlistManager, this.musicSearcher, this.cacheManager, this.loginManager);
             this.updateManager = new UpdateManager();


### PR DESCRIPTION
根本原因
通过代码分析,以下几个问题导致了这一行为:
1.PlaylistManager.js中的核心方法默认会自动播放:
setPlayingNow方法的autoPlay参数默认为 true
loadAndPlayAudio方法的autoplay参数默认为true
2.错误重试逻辑不考虑用户设置:
AudioPlayer.js中的错误事件处理程序无条件重试播放
tryPlayWithRetry方法没有autoPlay参数,总是尝试播放
3.播放控制方法没有正确传递autoPlay参数:
prev和next方法没有autoPlay参数
媒体会话处理程序不区分用户意图